### PR TITLE
fix: include prereleases when bumping pre versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ tagver().then(version => console.log(version));
 ``` javascript
 {
   cwd: './',  // Directory which tagver should use for git commands
-  filter: '*' // Semver filter to use. This will return the highest version based on the filter.
+  filter: '*', // Semver filter to use. This will return the highest version based on the filter.
+  includePrerelease: false // Include prerelease versions, when getting tags. This automatically gets set to true when bumping pre versions.
 }
 ```
 
@@ -60,7 +61,8 @@ tagver('prerelease', { preid: 'beta' }).then(version => console.log(version));
   base: '0.0.0',          // Initial version to increment when no version is found
   filter: '*',            // Semver filter to use. This will return the highest version based on the filter.
   preid: undefined,       // Preid to use when prerelease versions
-  branch: undefined       // Remote branch used to compare local changes against
+  branch: undefined,       // Remote branch used to compare local changes against
+  includePrerelease: false // Include prerelease versions, when getting tags. This automatically gets set to true when bumping pre versions.
 }
 ```
 
@@ -261,3 +263,7 @@ Prevents tagver from publishing created tags.
 ### --branch option
 
 Remote branch used to compare local changes against. Cannot tag unless remote and local repositories are in sync. Defaults to the default remote branch, usually master.
+
+### ---include-prerelease option
+
+Include prerelease versions, when getting tags. This automatically gets set to true when bumping pre versions.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,6 @@ Prevents tagver from publishing created tags.
 
 Remote branch used to compare local changes against. Cannot tag unless remote and local repositories are in sync. Defaults to the default remote branch, usually master.
 
-### ---include-prerelease option
+### --include-prerelease option
 
 Include prerelease versions, when getting tags. This automatically gets set to true when bumping pre versions.

--- a/api.js
+++ b/api.js
@@ -21,13 +21,13 @@ const checkOptions = options => new Promise((resolve, reject) => {
 
 
 // version - returns the current version number, if there is one.
-const latestVersionTag = options => checkOptions(options)
-.then(options => git.latestVersionTag(options));
+const latestVersionTag = (options, includePrerelease) => checkOptions(options)
+.then(options => git.latestVersionTag(options, includePrerelease));
 
 
 // bump - bumps up the version number.
 const bump = (version, options) => checkOptions(options)
-.then(options => latestVersionTag(options).then(currentVersion => {
+.then(options => latestVersionTag(options, (/^pre/).test(version)).then(currentVersion => {
   // x.x.x
   if (semver.valid(version)) {
     if (!currentVersion || semver.gt(version, currentVersion)) {

--- a/bin/tagver
+++ b/bin/tagver
@@ -44,6 +44,10 @@ const argv = yargs
   string: true,
   description: 'Remote branch used to compare local changes against'
 })
+.option('include-prerelease', {
+  boolean: true,
+  description: 'Include prerelease versions when getting version'
+})
 .help()
 .version()
 .argv;
@@ -57,6 +61,7 @@ options.filter = argv.filter;
 options.preid = argv.preid || undefined;
 options.base = argv.base;
 options.branch = argv.branch;
+options.includePrerelease = argv.includePrerelease;
 
 if (command) {
   api(command, options)

--- a/git-helper.js
+++ b/git-helper.js
@@ -22,12 +22,12 @@ const fetch = options => exec('git fetch', options).then(() => undefined);
 
 
 // Gets the latest/highest semver version tag
-const latestVersionTag = (options, includePrerelease) =>
+const latestVersionTag = options =>
 exec('git tag --list', options)
 .then(stdout => {
   stdout = stdout.split(/\n/)
   .filter(tag => semver.valid(tag) && semver.satisfies(tag, options.filter, {
-    includePrerelease: includePrerelease === true
+    includePrerelease: options.includePrerelease === true
   })).sort(semver.rcompare)[0];
   return semver.clean(stdout ? stdout.trim() : '') || '';
 });

--- a/git-helper.js
+++ b/git-helper.js
@@ -22,12 +22,13 @@ const fetch = options => exec('git fetch', options).then(() => undefined);
 
 
 // Gets the latest/highest semver version tag
-const latestVersionTag = options =>
+const latestVersionTag = (options, includePrerelease) =>
 exec('git tag --list', options)
 .then(stdout => {
   stdout = stdout.split(/\n/)
-  .filter(tag => semver.valid(tag) && semver.satisfies(tag, options.filter))
-  .sort(semver.rcompare)[0];
+  .filter(tag => semver.valid(tag) && semver.satisfies(tag, options.filter, {
+    includePrerelease: includePrerelease === true
+  })).sort(semver.rcompare)[0];
   return semver.clean(stdout ? stdout.trim() : '') || '';
 });
 


### PR DESCRIPTION
This always includes prerelease versions when bumping pre version.

```shell
$ git tag
1.30.21
3.8.6
4.0.0-0

$ tagver
3.8.6

$ tagver minor
3.9.0

$ tagver prerelease
4.0.0-1

$ tagver prepatch
4.0.1-0

$ tagver preminor
4.1.0-0

$ tagver premajor
5.0.0-0

$ tagver major
4.0.0

$ tagver 4.1.0
4.1.0
```